### PR TITLE
Fix emoji

### DIFF
--- a/rb/lib/twitter-text/autolink.rb
+++ b/rb/lib/twitter-text/autolink.rb
@@ -81,6 +81,8 @@ module Twitter
             link_to_screen_name(entity, chars, options, &block)
           elsif entity[:cashtag]
             link_to_cashtag(entity, chars, options, &block)
+          elsif entity[:emoji]
+            entity[:emoji]
           end
         end
       end

--- a/rb/lib/twitter-text/configuration.rb
+++ b/rb/lib/twitter-text/configuration.rb
@@ -24,17 +24,17 @@ module Twitter
       attr_reader :emoji_parsing_enabled
 
       CONFIG_V1 = File.join(
-        File.expand_path('../../../config', __FILE__), # project root
+        File.expand_path('../../../../config', __FILE__), # project root
         "#{PARSER_VERSION_CLASSIC}.json"
       )
 
       CONFIG_V2 = File.join(
-        File.expand_path('../../../config', __FILE__), # project root
+        File.expand_path('../../../../config', __FILE__), # project root
         "#{PARSER_VERSION_WEIGHTED}.json"
       )
 
       CONFIG_V3 = File.join(
-        File.expand_path('../../../config', __FILE__), # project root
+        File.expand_path('../../../../config', __FILE__), # project root
         "#{PARSER_VERSION_EMOJI_PARSING}.json"
       )
 

--- a/rb/lib/twitter-text/regex.rb
+++ b/rb/lib/twitter-text/regex.rb
@@ -33,8 +33,8 @@ module Twitter
 
       TLDS = YAML.load_file(
         File.join(
-          File.expand_path('../../..', __FILE__), # project root
-          'lib', 'assets', 'tld_lib.yml'
+          File.expand_path('../../../..', __FILE__), # project root
+          'conformance', 'tld_lib.yml'
         )
       )
 

--- a/rb/spec/autolinking_spec.rb
+++ b/rb/spec/autolinking_spec.rb
@@ -845,4 +845,14 @@ describe Twitter::TwitterText::Autolink do
     end
   end
 
+  describe "emoji" do
+    before do
+      @linker = TestAutolink.new
+    end
+    it "should not mess with emoji" do
+      result = @linker.auto_link("This 🤔 is some emoji: 🤔")
+      expect(result).to match(/🤔/)
+    end
+  end
+
 end


### PR DESCRIPTION
### Problem

The ruby gem didn't handle emoji entities when auto linking.

Solution

Added a stopgap to simply output the emoji when the emoji entity was encountered.

Result

Auto linking will no longer remove emojis.